### PR TITLE
Added the extra parameters needed to create an Azure connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,63 @@ Create L2 connection to seller service (shortcut to establish a simple connectio
   - speed-unit - MB / GB, must be allowed by the platform and the seller (can be retrieved with seller command)
   - notifications-email - email for notifications
 
+### Create Connection Flowchart
+
+```
++------------------------+               +---------------------------+                           +------------------------------------+
+|                        | Get Service   |                           |  Get Service              |                                    |
+|   User Initiates the   | Profile       |  Seller                   |  Profiles for Customer    |  Buyer                             |
+|   Creation Process     | +-----------> |  /serviceprofiles/{uuid}  | +-----------------------> |  /serviceprofiles/services/{uuid}  |
+|                        |               |                           |                           |                                    |
++------------------------+               +---------------------------+                           +------------------------------------+
+
+                                                                                                                          +         +
+                                                                                                                          |         |
+                                                                                                                          |         |
+                                                                                          Get Available Connection        |         |
+                                                                                          Tiers for the Profile           |         |
+                                                                                                                          |         |
+                                                                                        +-------------------------+       |         |
+                                                                                        |                         |       |         |
+                                                                                        |  /common/billingTiers/  | <-----+         |
+         +-------------------------------+                                              |                         |                 |
+         | NO                            |                                              +-------------------------+                 |
+         |                               |                                                                                          |
+         +                               v                                                                                          |
+                                                                                                                                    |
++-----------------+        +-----------------------------------------+   Validate Keys  +---------------------------+               |
+|                 |        |                                         |   with Provider  |                           | Get Service   |
+| Are Keys Valid? | <----+ |  Buyer                                  |                  |  Seller                   | Profile       |
+|                 |        |  /connections/validateAuthorizationKey  | <--------------+ |  /serviceprofiles/{uuid}  |               |
++-----------------+        |                                         |                  |                           | <-------------+
+                           +-----------------------------------------+                  +---------------------------+
+   YES  +
+        |                                                   ^
+        |                                                   |
+        v                                                   |
+                                                            |
+ +---------------+                                          |
+ | Buyer         |                                          |
+ | /connections/ |                                          |
+ |               |                                          |
+ +---------------+                                          |
+                                                            |
+        +                                                   |
+        |                                                   |
+        |                                                   |
+        v                                                   |
+                                                            |
+  +-------------+  YES                                      |
+  | Any Errors? |  +----------------------------------------+
+  +-------------+
+
+    NO  +
+        |            +--------------+
+        |            |  Connection  |
+        +--------->  |  Created     |
+                     +--------------+
+```
+
 ### Create connection to AWS
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -106,9 +106,17 @@ Create L2 connection to seller service (shortcut to establish a simple connectio
   - speed-unit - MB / GB, must be allowed by the platform and the seller (can be retrieved with seller command)
   - notifications-email - email for notifications
 
+### Create connection to AWS
+
 ```sh
 ecxctl connections create --name=EQUINIX_DEMO_CONN --port-uuid=2813d8f6-4623-4a5c-9c71-34de7e100933 --seller-metro=LD --seller-region=eu-west-1 --seller-uuid=9b460b5a-5461-4186-a3d5-2e8d8fb4c91b 
  --speed=50 --speed-unit=MB --vlan=3022 --auth-key=12345678912 --notifications-email=some@email.com
+```
+
+### Create connection to Azure
+
+```sh
+ecxctl connections create --name=EQUINIX_DEMO_CONN_AZ --name-sec=EQUINIX_DEMO_CONN_AZ_SEC --port-uuid=66284add-49a3-9a30-b4e0-30ac094f8af1 --port-uuid-sec=66284add-49a5-9a50-b4e0-30ac094f8af1 --seller-metro=LD --seller-region=westeurope --seller-uuid=a1390b22-bbe0-4e93-ad37-85beef9d254d --speed=50 --named-tag=Microsoft --speed-unit=MB --vlan=3143 --vlan-sec=3143 --auth-key=12345678912 --notifications-email=some@email.com
 ```
 
 List available connections

--- a/pkg/ecxctl/cmd/connections.go
+++ b/pkg/ecxctl/cmd/connections.go
@@ -30,8 +30,11 @@ var connectionMetro string
 
 // vars for create connection command
 var createL2SellerConPrimaryName string
+var createL2SellerConSecondaryName string
 var createL2SellerConPrimaryPortUUID string
+var createL2SellerConSecondaryPortUUID string
 var createL2SellerConPrimaryVlanSTag int64 // should be casted to int64
+var createL2SellerConSecondaryVlanSTag int64
 var createL2SellerConSellerProfileUUID string
 var createL2SellerConSellerRegion string
 var createL2SellerConSellerMetroCode string
@@ -39,6 +42,7 @@ var createL2SellerConSpeed int64 // should be casted to int64
 var createL2SellerConSpeedUnit string
 var createL2SellerConNotificationsEmail string
 var createL2SellerConAuthorizationKey string
+var createL2SellerConNamedTag string
 
 var connectionsCmd = &cobra.Command{
 	Use:   "connections",
@@ -85,8 +89,11 @@ func init() {
 	connectionsDeleteCmd.MarkFlagRequired("uuid")
 
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConPrimaryName, "name", "n", "", "name for the new connection")
+	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConSecondaryName, "name-sec", "", "", "name for the secondary connection")
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConPrimaryPortUUID, "port-uuid", "", "", "user port uuid")
+	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConSecondaryPortUUID, "port-uuid-sec", "", "", "secondary user port uuid")
 	connectionsCreateCmd.Flags().Int64VarP(&createL2SellerConPrimaryVlanSTag, "vlan", "", 0, "user vlan")
+	connectionsCreateCmd.Flags().Int64VarP(&createL2SellerConSecondaryVlanSTag, "vlan-sec", "", 0, "secondary user vlan")
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConSellerProfileUUID, "seller-uuid", "", "", "seller profile uuid (destination UUID)")
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConSellerRegion, "seller-region", "", "", "seller destination region (ex. AWS: eu-west-1)")
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConSellerMetroCode, "seller-metro", "", "", "seller destination metro code (ex.: LD)")
@@ -94,6 +101,7 @@ func init() {
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConSpeedUnit, "speed-unit", "", "", "connection speed unit MB, GB")
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConAuthorizationKey, "auth-key", "", "", "service authorization key (in AWS case use AWS Account ID)")
 	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConNotificationsEmail, "notifications-email", "", "", "email for notifications")
+	connectionsCreateCmd.Flags().StringVarP(&createL2SellerConNamedTag, "named-tag", "", "", "primary ZSide Vlan CTag")
 
 	connectionsCreateCmd.MarkFlagRequired("name")
 	connectionsCreateCmd.MarkFlagRequired("port-uuid")
@@ -184,12 +192,26 @@ func connectionsCreateCommand(cmd *cobra.Command, args []string) {
 	params := ConnectionsAPIClient.NewCreateL2SellerConnectionParams()
 
 	params.PrimaryName = createL2SellerConPrimaryName
+	if createL2SellerConSecondaryName != "" {
+		params.SecondaryName = createL2SellerConSecondaryName
+	}
+
 	params.PrimaryPortUUID = createL2SellerConPrimaryPortUUID
+	if createL2SellerConSecondaryPortUUID != "" {
+		params.SecondaryPortUUID = createL2SellerConSecondaryPortUUID
+	}
 
 	if createL2SellerConPrimaryVlanSTag == 0 {
 		panic(createL2SellerConPrimaryVlanSTag)
 	}
 	params.PrimaryVlanSTag = createL2SellerConPrimaryVlanSTag
+	if createL2SellerConSecondaryVlanSTag != 0 {
+		params.SecondaryVlanSTag = createL2SellerConSecondaryVlanSTag
+	}
+
+	if createL2SellerConNamedTag != "" {
+		params.NamedTag = createL2SellerConNamedTag
+	}
 
 	if createL2SellerConSpeed == 0 {
 		panic(createL2SellerConSpeed)

--- a/pkg/ecxlib/api/buyer/connections.go
+++ b/pkg/ecxlib/api/buyer/connections.go
@@ -320,16 +320,20 @@ func (m *ECXConnectionsAPI) CreateL2ConnectionSellerProfile(params *CreateL2Sell
 
 	ecxAPIParams := apiconnections.NewCreateConnectionUsingPOSTParams()
 	request := &models.PostConnectionRequest{
-		PrimaryName:      params.PrimaryName,
-		PrimaryPortUUID:  params.PrimaryPortUUID,
-		PrimaryVlanSTag:  params.PrimaryVlanSTag,
-		Speed:            params.Speed,
-		SpeedUnit:        params.SpeedUnit,
-		Notifications:    params.Notifications,
-		SellerRegion:     params.SellerRegion,     //"eu-west-1" // get from seller? this should be AWS
-		SellerMetroCode:  params.SellerMetroCode,  // provided by customer
-		AuthorizationKey: params.AuthorizationKey, // aws account id in this case
-		ProfileUUID:      seller.Payload.UUID,
+		PrimaryName:       params.PrimaryName,
+		PrimaryPortUUID:   params.PrimaryPortUUID,
+		PrimaryVlanSTag:   params.PrimaryVlanSTag,
+		SecondaryName:     params.SecondaryName,
+		SecondaryPortUUID: params.SecondaryPortUUID,
+		SecondaryVlanSTag: params.SecondaryVlanSTag,
+		Speed:             params.Speed,
+		SpeedUnit:         params.SpeedUnit,
+		Notifications:     params.Notifications,
+		SellerRegion:      params.SellerRegion,     //"eu-west-1" // get from seller? this should be AWS
+		SellerMetroCode:   params.SellerMetroCode,  // provided by customer
+		AuthorizationKey:  params.AuthorizationKey, // aws account id in this case
+		ProfileUUID:       seller.Payload.UUID,
+		NamedTag:          params.NamedTag,
 	}
 
 	ecxAPIParams.Request = request

--- a/pkg/ecxlib/api/buyer/connections.go
+++ b/pkg/ecxlib/api/buyer/connections.go
@@ -291,6 +291,10 @@ func (m *ECXConnectionsAPI) CreateL2ConnectionSellerProfile(params *CreateL2Sell
 		return nil, errors.New("must provide seller profile UUID")
 	}
 
+	if params.PrimaryPortUUID == "" {
+		return nil, errors.New("must provide a port id for the connection")
+	}
+
 	if m.Debug {
 		log.Printf("Trying to obtain seller profile for UUID %s\n", params.ProfileUUID)
 	}
@@ -316,6 +320,27 @@ func (m *ECXConnectionsAPI) CreateL2ConnectionSellerProfile(params *CreateL2Sell
 		return nil, errors.New(s)
 
 	}
+
+	// Validate that all the required information for the secondary port comes
+	if params.SecondaryName != "" || params.SecondaryPortUUID != "" || params.SecondaryVlanSTag != 0 || params.NamedTag != "" {
+		if params.SecondaryName == "" {
+			return nil, errors.New("must provide a name for the secondary connection")
+		}
+
+		if params.SecondaryPortUUID == "" {
+			return nil, errors.New("must provide the port id for the secondary connection")
+		}
+
+		if params.SecondaryVlanSTag == 0 {
+			return nil, errors.New("must provide the vlan for the secondary connection")
+		}
+
+		// Validate that ports are not the same
+		if params.PrimaryPortUUID == params.SecondaryPortUUID {
+			return nil, errors.New("must provide a different port id for the secondary connection")
+		}
+	}
+
 	// seller.Payload.IntegrationID
 
 	ecxAPIParams := apiconnections.NewCreateConnectionUsingPOSTParams()


### PR DESCRIPTION
I've added the parameters needed to create a connection to Azure.

For example, you can create a connection by running the following command:

`ecxctl connections create --name=EQUINIX_DEMO_CONN_AZ --name-sec=EQUINIX_DEMO_CONN_AZ_SEC --port-uuid=66284add-49a3-9a30-b4e0-30ac094f8af1 --port-uuid-sec=66284add-49a5-9a50-b4e0-30ac094f8af1 --seller-metro=LD --seller-region=westeurope --seller-uuid=a1390b22-bbe0-4e93-ad37-85beef9d254d --speed=50 --named-tag=Microsoft --speed-unit=MB --vlan=3143 --vlan-sec=3143 --auth-key=12345678912 --notifications-email=some@email.com
`